### PR TITLE
Fixed Typo of Getting Started command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A Next.js starter that includes all you need to build amazing projects 🔥. For
 The best way to start with this template is using `create-next-app`.
 
 ```
-npx create-next-app ts-next -e https://github.com/chhpt/typescript-nextjs-starter
+npx create-next-app ts-next -e https://github.com/chhpt/nextjs-starter
 ```
 
 If you prefer you can clone this repository and run the following commands inside the project folder:


### PR DESCRIPTION
I fixed the getting started command to start with this template. 

It should be 

```
npx create-next-app ts-next -e https://github.com/chhpt/nextjs-starter
```

instead of

```
npx create-next-app ts-next -e https://github.com/chhpt/typescript-nextjs-starter
```


