### PR TITLE
Feature to add custom layout per page by defining getLayout.

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,19 @@
+import type { ReactElement, ReactNode } from 'react'
+import type { NextPage } from 'next'
 import { AppProps } from 'next/app'
 import { Layout } from '@/components'
 import '@/styles/global.css'
 
-export default function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
-  )
+export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactNode
+}
+
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout
+}
+
+export default function MyApp({ Component, pageProps }: AppPropsWithLayout) {
+  const getLayout = Component.getLayout || ((page) => <Layout>{page}</Layout>)
+
+  return getLayout(<Component {...pageProps} />)
 }


### PR DESCRIPTION
# Description 

Define layout for the application and each page in nextjs application. 

### Define custom layout for `user` page .

```import { Layout } from '@/components'
import { ReactElement } from 'react'
import type { NextPageWithLayout } from './_app'

function User() {
  return <div className="content">john doe</div>
}

User.getLayout = function getLayout(page: ReactElement) {
  return <div className="layout">{page}</div>
}

export default User as NextPageWithLayout
```



